### PR TITLE
Added callBegin option to begin() for alt I2c pin usage

### DIFF
--- a/Adafruit_ADS1X15.cpp
+++ b/Adafruit_ADS1X15.cpp
@@ -58,13 +58,19 @@ Adafruit_ADS1115::Adafruit_ADS1115() {
 
     @param i2c_addr I2C address of device
     @param wire I2C bus
+	@param bool callBegin - Use false to call begin() manually (e.g. for 2ndary I2C pins)
 
     @return true if successful, otherwise false
 */
 /**************************************************************************/
-bool Adafruit_ADS1X15::begin(uint8_t i2c_addr, TwoWire *wire) {
+bool Adafruit_ADS1X15::begin(uint8_t i2c_addr, TwoWire *wire, bool callBegin) {
   m_i2c_dev = new Adafruit_I2CDevice(i2c_addr, wire);
-  return m_i2c_dev->begin();
+  if (callBegin) {
+	return m_i2c_dev->begin();
+  }
+  else {
+	return true;
+  }
 }
 
 /**************************************************************************/

--- a/Adafruit_ADS1X15.h
+++ b/Adafruit_ADS1X15.h
@@ -147,7 +147,7 @@ protected:
   uint16_t m_dataRate;           ///< Data rate
 
 public:
-  bool begin(uint8_t i2c_addr = ADS1X15_ADDRESS, TwoWire *wire = &Wire);
+  bool begin(uint8_t i2c_addr = ADS1X15_ADDRESS, TwoWire *wire = &Wire, bool callBegin = true);
   int16_t readADC_SingleEnded(uint8_t channel);
   int16_t readADC_Differential_0_1();
   int16_t readADC_Differential_2_3();


### PR DESCRIPTION
# Features
- Added callBegin option to Adafruit_ADS1X15.begin() to allow for alternate I2c pin usage
- callBegin defaults to true and performs as previously expected a for backward compatibility
- Setting callBegin = false omits m_i2c_dev->begin(); and simply returns true;